### PR TITLE
[Actualizar configuración de Nginx y .gitignore para entorno productivo]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,5 @@ addons/
 
 odoo-filestore/
 odoo-filestore/db_retana/
+
+nginx/ssl/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
         depends_on:
             - odoo_17_retana
         ports:
-            - "4444:80"
+            - "80:80"
             - "8443:443"
         volumes:
             - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -9,7 +9,7 @@ upstream odoochat {
 # Redireccionar HTTP a HTTPS
 server {
     listen 80;
-    server_name _;
+    server_name retana.info www.retana.info;
     
     # Para desarrollo local, permite HTTP directamente
     # Descomenta las siguientes líneas para forzar HTTPS en producción
@@ -18,14 +18,13 @@ server {
     # Configuración para desarrollo local (HTTP)
     location / {
         proxy_pass http://odoo;
-        proxy_set_header Host $host:$server_port;
+        proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $host:$server_port;
+        proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Port $server_port;
-        proxy_redirect http://localhost/ http://localhost:4444/;
-        proxy_redirect http://$host/ http://$host:4444/;
+        proxy_redirect off;
         
         # Aumentar timeouts para operaciones largas
         proxy_read_timeout 720s;
@@ -39,11 +38,11 @@ server {
     # Longpolling para chat/notificaciones
     location /longpolling {
         proxy_pass http://odoochat;
-        proxy_set_header Host $host:$server_port;
+        proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $host:$server_port;
+        proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Port $server_port;
         proxy_redirect off;
     }
@@ -53,11 +52,11 @@ server {
         proxy_pass http://odoochat;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        proxy_set_header Host $host:$server_port;
+        proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $host:$server_port;
+        proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Port $server_port;
         proxy_redirect off;
     }
@@ -68,11 +67,11 @@ server {
         proxy_buffering on;
         expires 864000;
         proxy_pass http://odoo;
-        proxy_set_header Host $host:$server_port;
+        proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $host:$server_port;
+        proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Port $server_port;
     }
 }


### PR DESCRIPTION
- Modificar el puerto de Nginx de 4444 a 80.
- Especificar nombres de servidor en la configuración de Nginx.
- Ajustar encabezados de proxy para simplificar la configuración.
- Agregar ruta de SSL en .gitignore.