### PR TITLE
Eliminar plantilla de encabezado y ajustar redirección en el formulario de inicio de sesión

### DIFF
--- a/extra-addons/retana_login_custom/views/retana_login_templates.xml
+++ b/extra-addons/retana_login_custom/views/retana_login_templates.xml
@@ -4,6 +4,6 @@
         <xpath expr="//form[contains(@class, 'oe_login_form')]" position="attributes">
             <attribute name="class" add="retana-login-form" separator=" "/>
         </xpath>
-        <xpath expr="//form[contains(@class, 'oe_login_form')]//button[@name='redirect' and @value='/web/become']" position="replace"/>
+        <xpath expr="//form[contains(@class, 'oe_login_form')]//button[@name='redirect']" position="replace"/>
     </template>
 </odoo>

--- a/extra-addons/retana_web/__manifest__.py
+++ b/extra-addons/retana_web/__manifest__.py
@@ -14,7 +14,6 @@
     "depends": ["base", "website", "retana_bills"],
     "data": [
         "views/retana_bills_templates.xml",
-        "views/retana_header_templates.xml",
         "views/retana_site_menus.xml",
     ],
     "assets": {

--- a/extra-addons/retana_web/views/retana_header_templates.xml
+++ b/extra-addons/retana_web/views/retana_header_templates.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <record id="retana_header_menu" model="ir.ui.view">
-        <field name="active" eval="False"/>
-    </record>
-</odoo>


### PR DESCRIPTION
This pull request primarily cleans up unused or unnecessary code related to the web and login templates. The most significant changes involve removing a template file and updating dependencies and template logic to reflect this removal.

Template and dependency cleanup:

* Removed the `retana_header_templates.xml` file and its reference from the `retana_web` module's manifest to eliminate unused header menu code. (`extra-addons/retana_web/views/retana_header_templates.xml`, `extra-addons/retana_web/__manifest__.py`) [[1]](diffhunk://#diff-ebff44a5867327e40451a7e4bc89913ac8ec5e7f4a1937fbb99c89ded7179a58L1-L6) [[2]](diffhunk://#diff-41b52fbb9a46e9e5a8e75c904056f679eaf214a9823c4bca2b0ff38c2aa882e9L17)

Login template adjustment:

* Updated the login template's XPath expression to more broadly target buttons with `name='redirect'`, instead of only those with a specific value, making the replacement more flexible. (`extra-addons/retana_login_custom/views/retana_login_templates.xml`)