### PR TITLE
[#92 Agregar campo 'Mostrar firma' en el modelo de presupuesto y actualizar la vista del formulario]

### DIFF
--- a/extra-addons/retana_bills/models/retana_budgets.py
+++ b/extra-addons/retana_bills/models/retana_budgets.py
@@ -40,6 +40,7 @@ class RetanaBudget(models.Model):
     line_ids            =fields.One2many('retana.budget.line', 'budget_id', string='Líneas de Presupuesto', tracking=True)
     downpayment_amount  =fields.Monetary(string='Anticipo', currency_field='currency_id', tracking=True)
     taxes_ids           =fields.Many2many('account.tax', string='Impuestos', tracking=True)
+    show_sign           =fields.Boolean(string='Mostrar firma', default=True, tracking=True)
     
     @api.onchange('budget_type_id', 'client_id', 'building_id')
     def _onchange_budget_type_id(self):

--- a/extra-addons/retana_bills/report/retana_budget_report.xml
+++ b/extra-addons/retana_bills/report/retana_budget_report.xml
@@ -63,6 +63,7 @@
                         </t>
 
                         <!-- Tabla de conceptos -->
+                        <t t-set="show_amount_columns" t-value="not o.budget_type_id.is_material_list and any(l.display_type not in ('line_section', 'line_note') and not (l.quantity == 0 and l.unit_price == 0 and l.subtotal == 0) for l in o.line_ids)"/>
                         <table style="width: 100%; border-collapse: collapse; margin: 20px 0; font-size: 10pt;">
                             <thead>
                                 <t t-if="o.budget_type_id.is_material_list">
@@ -74,12 +75,14 @@
                                 </t>
                                 <t t-else="">
                                     <!-- Encabezados normales (con precios) -->
-                                    <tr>
-                                        <th style="text-align: left; padding: 6px 4px; font-weight: bold; width: 50%;"></th>
-                                        <th style="text-align: center; padding: 6px 4px; font-weight: bold; width: 10%;">PZA.</th>
-                                        <th style="text-align: right; padding: 6px 4px; font-weight: bold; width: 20%;">PRECIO</th>
-                                        <th style="text-align: right; padding: 6px 4px; font-weight: bold; width: 20%;">TOTAL</th>
-                                    </tr>
+                                    <t t-if="show_amount_columns">
+                                        <tr>
+                                            <th style="text-align: left; padding: 6px 4px; font-weight: bold; width: 50%;"></th>
+                                            <th style="text-align: center; padding: 6px 4px; font-weight: bold; width: 10%;">PZA.</th>
+                                            <th style="text-align: right; padding: 6px 4px; font-weight: bold; width: 20%;">PRECIO</th>
+                                            <th style="text-align: right; padding: 6px 4px; font-weight: bold; width: 20%;">TOTAL</th>
+                                        </tr>
+                                    </t>
                                 </t>
                             </thead>
                             <tbody>
@@ -124,39 +127,51 @@
                                         <t t-else="">
                                             <!-- Formato normal (con precios) -->
                                             <tr>
-                                                <td style="padding: 4px; vertical-align: top; text-align: left;">
-                                                    <t t-if="line.description and line.product_id and line.description != line.product_id.name">
-                                                        <t t-esc="line.description.upper()"/>
-                                                    </t>
-                                                    <t t-else="">
-                                                        <t t-esc="(line.product_id.name or '').upper()"/>
-                                                    </t>
-                                                </td>
-                                                <td style="text-align: center; padding: 4px; vertical-align: top;">
-                                                    <t t-esc="int(line.quantity)"/>
-                                                    <t t-if="line.uom_id and (line.uom_id.name or '').strip().upper() != 'UNIDADES'">
-                                                        <t t-esc="line.uom_id.name"/>
-                                                    </t>
-                                                </td>
-                                                <td style="text-align: right; padding: 4px; vertical-align: top;">
-                                                    $<t t-esc="'{:,.2f}'.format(line.unit_price)"/>
-                                                </td>
-                                                <td style="text-align: right; padding: 4px; vertical-align: top;">
-                                                    <t t-if="line_last">
-                                                        <div style="display: inline-block; border-bottom: 2px solid black; padding-bottom: 2px;">
+                                                <t t-if="line.quantity == 0 and line.unit_price == 0 and line.subtotal == 0">
+                                                    <td colspan="4" style="padding: 4px; vertical-align: top; text-align: left;">
+                                                        <t t-if="line.description and line.product_id and line.description != line.product_id.name">
+                                                            <t t-esc="line.description.upper()"/>
+                                                        </t>
+                                                        <t t-else="">
+                                                            <t t-esc="(line.product_id.name or '').upper()"/>
+                                                        </t>
+                                                    </td>
+                                                </t>
+                                                <t t-else="">
+                                                    <td style="padding: 4px; vertical-align: top; text-align: left;">
+                                                        <t t-if="line.description and line.product_id and line.description != line.product_id.name">
+                                                            <t t-esc="line.description.upper()"/>
+                                                        </t>
+                                                        <t t-else="">
+                                                            <t t-esc="(line.product_id.name or '').upper()"/>
+                                                        </t>
+                                                    </td>
+                                                    <td style="text-align: center; padding: 4px; vertical-align: top;">
+                                                        <t t-esc="int(line.quantity)"/>
+                                                        <t t-if="line.uom_id and (line.uom_id.name or '').strip().upper() != 'UNIDADES'">
+                                                            <t t-esc="line.uom_id.name"/>
+                                                        </t>
+                                                    </td>
+                                                    <td style="text-align: right; padding: 4px; vertical-align: top;">
+                                                        $<t t-esc="'{:,.2f}'.format(line.unit_price)"/>
+                                                    </td>
+                                                    <td style="text-align: right; padding: 4px; vertical-align: top;">
+                                                        <t t-if="line_last">
+                                                            <div style="display: inline-block; border-bottom: 2px solid black; padding-bottom: 2px;">
+                                                                $<t t-esc="'{:,.2f}'.format(line.subtotal)"/>
+                                                            </div>
+                                                        </t>
+                                                        <t t-else="">
                                                             $<t t-esc="'{:,.2f}'.format(line.subtotal)"/>
-                                                        </div>
-                                                    </t>
-                                                    <t t-else="">
-                                                        $<t t-esc="'{:,.2f}'.format(line.subtotal)"/>
-                                                    </t>
-                                                </td>
+                                                        </t>
+                                                    </td>
+                                                </t>
                                             </tr>
                                         </t>
                                     </t>
                                 </t>
                                 <!-- No mostrar totales si es lista de materiales -->
-                                <t t-if="not o.budget_type_id.is_material_list">
+                                <t t-if="not o.budget_type_id.is_material_list and show_amount_columns">
                                     <!-- Fila del subtotal (solo si hay IVA, descuento o anticipo) -->
                                     <tr t-if="o.tax_amount > 0 or o.discount_amount > 0 or o.downpayment_amount > 0">
                                         <td colspan="3" style="text-align: right; padding: 8px 4px; font-weight: bold;">
@@ -207,23 +222,25 @@
                         </table>
 
                         <!-- Sección de atentamente -->
-                        <div style="margin-top: 80px; text-align: center;">
-                            <div style="font-weight: bold; font-size: 11pt; letter-spacing: 8px; margin-bottom: 50px;">
-                                A T E N T A M E N T E
-                            </div>
-                            
-                            <div style="font-weight: bold; font-size: 10pt; margin-bottom: 60px;">
-                                <t t-if="o.total_amount and not o.budget_type_id.is_material_list">
-                                    <t t-esc="o.currency_id.amount_to_text(o.total_amount).upper()"/> M.N
-                                </t>
-                            </div>
+                        <t t-if="o.show_sign">
+                            <div style="margin-top: 80px; text-align: center;">
+                                <div style="font-weight: bold; font-size: 11pt; letter-spacing: 8px; margin-bottom: 50px;">
+                                    A T E N T A M E N T E
+                                </div>
+                                
+                                <div style="font-weight: bold; font-size: 10pt; margin-bottom: 60px;">
+                                    <t t-if="o.total_amount and not o.budget_type_id.is_material_list">
+                                        <t t-esc="o.currency_id.amount_to_text(o.total_amount).upper()"/> M.N
+                                    </t>
+                                </div>
 
-                            <div style="margin: 0 auto; width: 350px;">
-                                <div style="border-top: 1.5px solid black; padding-top: 8px; font-weight: bold; font-size: 10pt;">
-                                    <t t-esc="company_info.company_name"/>
+                                <div style="margin: 0 auto; width: 350px;">
+                                    <div style="border-top: 1.5px solid black; padding-top: 8px; font-weight: bold; font-size: 10pt;">
+                                        <t t-esc="company_info.company_name"/>
+                                    </div>
                                 </div>
                             </div>
-                        </div>
+                        </t>
 
                     </div>
                 </div>

--- a/extra-addons/retana_bills/views/retana_budget_views.xml
+++ b/extra-addons/retana_bills/views/retana_budget_views.xml
@@ -42,6 +42,7 @@
                             <field name="discount" widget="percentage"/>
                             <field name="taxes_ids" widget="many2many_tags"/>   
                             <field name="currency_id" required="1"/>
+                            <field name="show_sign"/>
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
This pull request introduces improvements to the budget reporting feature in the `retana_bills` module, focusing on enhanced display logic for budget lines and signature sections. It adds configurability for showing the signature, refines the rendering of concept tables, and ensures cleaner presentation of lines with zero values.

Key changes:

**Budget Model and Configuration:**
* Added a new boolean field `show_sign` to the `RetanaBudget` model, allowing users to control whether the signature section is displayed in reports. This field is now also available in the budget form view. [[1]](diffhunk://#diff-a6d677db410244b799082b4e892b85d0e29e82f8b8447c065e4ad3b927fd78c0R43) [[2]](diffhunk://#diff-2bfb638d547702db2f326b65e94e41c17d4fefa8b814637672fe7381e4fd76d5R45)

**Report Rendering Logic:**
* Updated the budget report template (`retana_budget_report.xml`) to conditionally display the signature section based on the new `show_sign` field. [[1]](diffhunk://#diff-89875a1a80dd617c6cc50120b65d50fe8afef72a60d5bf7ae0ac9b21ada404d5R225) [[2]](diffhunk://#diff-89875a1a80dd617c6cc50120b65d50fe8afef72a60d5bf7ae0ac9b21ada404d5R243)
* Improved logic for displaying amount columns in the concepts table: amount columns are now hidden if all lines have zero values or are of certain display types, resulting in a cleaner report for material lists or empty budgets. [[1]](diffhunk://#diff-89875a1a80dd617c6cc50120b65d50fe8afef72a60d5bf7ae0ac9b21ada404d5R66) [[2]](diffhunk://#diff-89875a1a80dd617c6cc50120b65d50fe8afef72a60d5bf7ae0ac9b21ada404d5R78-R86) [[3]](diffhunk://#diff-89875a1a80dd617c6cc50120b65d50fe8afef72a60d5bf7ae0ac9b21ada404d5R168-R174)
* Enhanced the rendering of budget lines: lines with zero quantity, price, and subtotal are now presented as section headers or notes, spanning all columns for clarity.